### PR TITLE
Modifying LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,11 @@
 MIT License
 
-Copyright (c) 2023 RealVNC Limited
+Copyright (c) 2024 openrport authors
+
+Copyright for portions of the project openrport are held by CloudRadar, 2020 as part of project rport.
+Copyright for portions of the project openrport are held by RealVNC limited, 2023 as part of project rport.
+All other copyright for the project openrport is held by the openrport authors, 2024.
+
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
- Respecting old owners CloudRadar, RealVNC limited. (I still have cloned repos where CloudRadar is standing in the license.)
- Adding current 2024 copyright holders -> openrport authors